### PR TITLE
Develop

### DIFF
--- a/DotNetPivotalTrackerApi.Portable/DotNetPivotalTrackerApi.Portable.csproj
+++ b/DotNetPivotalTrackerApi.Portable/DotNetPivotalTrackerApi.Portable.csproj
@@ -85,6 +85,9 @@
     <Compile Include="..\PivotalTrackerApi\Models\Comments\PivotalComment.cs">
       <Link>Models\Comments\PivotalComment.cs</Link>
     </Compile>
+    <Compile Include="..\PivotalTrackerApi\Models\PivotalModel.cs">
+      <Link>Models\PivotalModel.cs</Link>
+    </Compile>
     <Compile Include="..\PivotalTrackerApi\Models\Project\PivotalProject.cs">
       <Link>Models\Project\PivotalProject.cs</Link>
     </Compile>

--- a/DotNetPivotalTrackerApi.Portable/Properties/AssemblyInfo.cs
+++ b/DotNetPivotalTrackerApi.Portable/Properties/AssemblyInfo.cs
@@ -24,5 +24,5 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.6")]
-[assembly: AssemblyFileVersion("1.0.6")]
+[assembly: AssemblyVersion("1.1.0")]
+[assembly: AssemblyFileVersion("1.0.0")]

--- a/Examples.Portable/App.xaml.cs
+++ b/Examples.Portable/App.xaml.cs
@@ -14,6 +14,7 @@ using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
+using DotNetPivotalTrackerApi.Models.Stories;
 using DotNetPivotalTrackerApi.Services;
 
 namespace Examples.Portable
@@ -38,7 +39,7 @@ namespace Examples.Portable
         /// will be used such as when the application is launched to open a specific file.
         /// </summary>
         /// <param name="e">Details about the launch request and process.</param>
-        protected override void OnLaunched(LaunchActivatedEventArgs e)
+        protected override async void OnLaunched(LaunchActivatedEventArgs e)
         {
 #if DEBUG
             if (System.Diagnostics.Debugger.IsAttached)
@@ -49,7 +50,11 @@ namespace Examples.Portable
             Frame rootFrame = Window.Current.Content as Frame;
 
             var tracker = new PivotalTracker();
-            var authorisedUser = tracker.AuthorizeAsync("your_uesrname", "your_password").Result;
+            var authorisedUser = await tracker.AuthorizeAsync("your_username", "your_password");
+
+            var projects = await tracker.GetProjectsAsync();
+            var story = await tracker.CreateNewStoryAsync(projects.First().Id,
+                new PivotalStory {Name = "I'm from uwp"});
 
             // Do not repeat app initialization when the Window already has content,
             // just ensure that the window is active

--- a/Package.nuspec
+++ b/Package.nuspec
@@ -10,7 +10,8 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <releaseNotes>
       Features:
-      - Refactored PivotalTracker class to be async
+      - [BREAKING CHANGE] Refactored public PivotalTracker methods to be async
+      - [BREAKING CHANGE] Removed the "PivotalNew" models. All methods (Get and Create) now use the same model
       - Added authorisation for username/password authentication
     </releaseNotes>
     <summary>

--- a/Package.nuspec
+++ b/Package.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>Mbrewerton.DotNetPivotalTrackerApi</id>
-    <version>1.0.6-alpha</version>
+    <version>1.1.0-alpha</version>
     <authors>Matt Brewerton</authors>
     <owners>mbrewerton</owners>
     <licenseUrl>https://opensource.org/licenses/MIT</licenseUrl>
@@ -10,6 +10,7 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <releaseNotes>
       Features:
+      - Refactored PivotalTracker class to be async
       - Added authorisation for username/password authentication
     </releaseNotes>
     <summary>

--- a/PivotalTrackerApi/DotNetPivotalTrackerApi.csproj
+++ b/PivotalTrackerApi/DotNetPivotalTrackerApi.csproj
@@ -53,14 +53,11 @@
     <Compile Include="Exceptions\PivotalNotFoundException.cs" />
     <Compile Include="Exceptions\PivotalUserException.cs" />
     <Compile Include="Models\Attachments\PivotalAttachment.cs" />
-    <Compile Include="Models\Attachments\PivotalNewAttachment.cs" />
     <Compile Include="Models\Comments\PivotalComment.cs" />
     <Compile Include="Models\PivotalModel.cs" />
     <Compile Include="Models\Project\PivotalProject.cs" />
     <Compile Include="Models\Stories\PivotalLabel.cs" />
-    <Compile Include="Models\Stories\PivotalNewStory.cs" />
     <Compile Include="Models\Stories\PivotalStory.cs" />
-    <Compile Include="Models\Tasks\PivotalNewTask.cs" />
     <Compile Include="Models\Tasks\PivotalTask.cs" />
     <Compile Include="Models\User\PivotalUser.cs" />
     <Compile Include="Models\User\PivotalUserProject.cs" />

--- a/PivotalTrackerApi/Models/Attachments/PivotalAttachment.cs
+++ b/PivotalTrackerApi/Models/Attachments/PivotalAttachment.cs
@@ -1,6 +1,6 @@
 ﻿namespace DotNetPivotalTrackerApi.Models.Attachments
 {
-    public class PivotalAttachment
+    public class PivotalAttachment : PivotalModel
     {
         public int Id { get; set; }
         public string FileName { get; set; }

--- a/PivotalTrackerApi/Models/Comments/PivotalComment.cs
+++ b/PivotalTrackerApi/Models/Comments/PivotalComment.cs
@@ -3,16 +3,16 @@ using DotNetPivotalTrackerApi.Models.Attachments;
 
 namespace DotNetPivotalTrackerApi.Models.Comments
 {
-    public class PivotalComment : PivotalNewComment
-    {
-        public List<int> FileAttachmentIds { get; set; }
-        public int? PersonId { get; set; }
-    }
-    public class PivotalNewComment
+    //public class PivotalComment : PivotalNewComment
+    //{
+    //}
+    public class PivotalComment : PivotalModel
     {
         public int StoryId { get; set; }
         public int ProjectId { get; set; }
         public List<PivotalAttachment> FileAttachments { get; set; }
+        public List<int> FileAttachmentIds { get; set; }
+        public int? PersonId { get; set; }
         public int Id { get; set; }
         public string Text { get; set; }        
     }

--- a/PivotalTrackerApi/Models/PivotalModel.cs
+++ b/PivotalTrackerApi/Models/PivotalModel.cs
@@ -2,5 +2,6 @@
 {
     public class PivotalModel
     {
+        public string Kind { get; set; }
     }
 }

--- a/PivotalTrackerApi/Models/Project/PivotalProject.cs
+++ b/PivotalTrackerApi/Models/Project/PivotalProject.cs
@@ -1,6 +1,6 @@
 ﻿namespace DotNetPivotalTrackerApi.Models.Project
 {
-    public class PivotalProject
+    public class PivotalProject : PivotalModel
     {
         public int Id { get; set; }
         public string Name { get; set; }

--- a/PivotalTrackerApi/Models/Stories/PivotalLabel.cs
+++ b/PivotalTrackerApi/Models/Stories/PivotalLabel.cs
@@ -1,6 +1,6 @@
 ﻿namespace DotNetPivotalTrackerApi.Models.Stories
 {
-    public class PivotalLabel
+    public class PivotalLabel : PivotalModel
     {
         public int? Id { get; set; }
         public string Name { get; set; }

--- a/PivotalTrackerApi/Models/Stories/PivotalStory.cs
+++ b/PivotalTrackerApi/Models/Stories/PivotalStory.cs
@@ -4,19 +4,19 @@ using DotNetPivotalTrackerApi.Enums;
 
 namespace DotNetPivotalTrackerApi.Models.Stories
 {
-    public class PivotalStory
+    public class PivotalStory : PivotalModel
     {
         public int ProjectId { get; set; }
 
-        public int Id { get; set; }
+        public int? Id { get; set; }
         public string Name { get; set; }
         public string Description { get; set; }
-        public StoryType StoryType { get; set; }
-        public StoryState StoryState { get; set; }
+        public string StoryType { get; set; }
+        public string StoryState { get; set; }
         public float Estimate { get; set; }
-        public DateTime Deadline { get; set; }
-        public int RequestedById { get; set; }
+        public DateTime? Deadline { get; set; }
+        public int? RequestedById { get; set; }
         public List<int> OwnerIds { get; set; }
-        public List<PivotalLabel> Labels { get; set; }
+        public List<string> Labels { get; set; }
     }
 }

--- a/PivotalTrackerApi/Models/Tasks/PivotalTask.cs
+++ b/PivotalTrackerApi/Models/Tasks/PivotalTask.cs
@@ -2,7 +2,7 @@
 
 namespace DotNetPivotalTrackerApi.Models.Tasks
 {
-    public class PivotalTask
+    public class PivotalTask : PivotalModel
     {
         public int? TaskId { get; set; }
         public int Id { get; set; }
@@ -12,30 +12,5 @@ namespace DotNetPivotalTrackerApi.Models.Tasks
         public int Position { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
-        /*
-         id int 
- —  Database id of the task. This field is read only. This field is always returned.
- 
-story_id int 
- —  The id of the story to which the task is connected. This field is read only.
- 
-description string[1000] 
-Required On Create  —  Content of the task. This field is required on create.
- 
-complete boolean 
- —  Flag showing the completion of the task.
- 
-position int 
- —  Offset from the top of the task list. Positions start counting from 1 for the first task on a story.
- 
-created_at datetime 
- —  Creation time. This field is read only.
- 
-updated_at datetime 
- —  Time of last update. This field is read only.
- 
-kind string 
- —  The type of this object: task. This field is read only.
-         */
     }
 }

--- a/PivotalTrackerApi/Models/User/PivotalUser.cs
+++ b/PivotalTrackerApi/Models/User/PivotalUser.cs
@@ -2,7 +2,7 @@
 
 namespace DotNetPivotalTrackerApi.Models.User
 {
-    public class PivotalUser
+    public class PivotalUser : PivotalModel
     {
         public int Id { get; set; }
 

--- a/PivotalTrackerApi/Models/User/PivotalUserProject.cs
+++ b/PivotalTrackerApi/Models/User/PivotalUserProject.cs
@@ -1,6 +1,6 @@
 ﻿namespace DotNetPivotalTrackerApi.Models.User
 {
-    public class PivotalUserProject
+    public class PivotalUserProject : PivotalModel
     {
         public int ProjectId { get; set; }
         public string ProjectName { get; set; }

--- a/PivotalTrackerApi/Properties/AssemblyInfo.cs
+++ b/PivotalTrackerApi/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.6")]
-[assembly: AssemblyFileVersion("1.0.6")]
+[assembly: AssemblyVersion("1.1.0")]
+[assembly: AssemblyFileVersion("1.1.0")]

--- a/PivotalTrackerApi/Services/HttpService.cs
+++ b/PivotalTrackerApi/Services/HttpService.cs
@@ -47,7 +47,7 @@ namespace DotNetPivotalTrackerApi.Services
                 authoriseRequest.Headers.Authorization = new AuthenticationHeaderValue("basic", Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}")));
                 authoriseRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
    
-                return authClient.SendAsync(authoriseRequest).Result;
+                return await authClient.SendAsync(authoriseRequest);
             }
         }
         

--- a/PivotalTrackerApi/Services/HttpService.cs
+++ b/PivotalTrackerApi/Services/HttpService.cs
@@ -112,7 +112,11 @@ namespace DotNetPivotalTrackerApi.Services
             CheckTokenExists();
             return await HttpClient.DeleteAsync(path);
         }
-
+        
+        /// <summary>
+        /// Checks if the Api Token exists on the HttpService instance. Note: This is not required when calling the <see cref="AuthorizeAsync"/> method.
+        /// </summary>
+        /// <exception cref="PivotalAuthorisationException"></exception>
         private void CheckTokenExists()
         {
             if (string.IsNullOrEmpty(_apiToken))

--- a/PivotalTrackerTests/Services/PivotalTrackerTestClass.cs
+++ b/PivotalTrackerTests/Services/PivotalTrackerTestClass.cs
@@ -42,9 +42,25 @@ namespace PivotalTrackerTests.Services
             tracker.AuthorizeAsync("testUser", "testPassword");
             FakeHttpService.Setup(x => x.GetAsync(It.IsAny<string>())).Returns(Task.FromResult(response));
 
-            var user = tracker.GetUser();
+            var user = tracker.GetUser().Result;
 
             Assert.Equal(user.ApiToken, returnUser.ApiToken);
+        }
+
+        [Fact]
+        public void Test_PivotalTracker_Authentication_Sets_ApiToken()
+        {
+            var tracker = GetTracker();
+            var returnUser = new PivotalUser
+            {
+                Username = "TestUser",
+                ApiToken = "MyToken"
+            };
+            var response = CreateResponse(returnUser);
+            FakeHttpService.Setup(x => x.AuthorizeAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(response));
+            var auth = tracker.AuthorizeAsync("test", "test").Result;
+
+            Assert.Equal(returnUser.ApiToken, tracker.ApiToken);
         }
 
         [Fact]
@@ -95,16 +111,16 @@ namespace PivotalTrackerTests.Services
             var response = CreateResponse(returnProjects);
             FakeHttpService.Setup(x => x.GetAsync(It.IsAny<string>())).Returns(Task.FromResult(response));
 
-            var projects = tracker.GetProjects();
+            var projects = tracker.GetProjects().Result;
 
             Assert.Equal(3, projects.Count);
         }
 
         [Fact]
-        private void Test_Get_Current_Project_With_No_ProjectId_Or_Persisted_Throws()
+        private async void Test_Get_Current_Project_With_No_ProjectId_Or_Persisted_Throws()
         {
             var tracker = GetTracker();
-            Assert.Throws<PivotalException>(() => tracker.GetCurrentProject());
+            await Assert.ThrowsAsync<PivotalException>(() => tracker.GetCurrentProjectAsync());
         }
 
         [Fact]
@@ -115,7 +131,7 @@ namespace PivotalTrackerTests.Services
             var response = CreateResponse(returnProject);
             FakeHttpService.Setup(x => x.GetAsync(It.IsAny<string>())).Returns(Task.FromResult(response));
 
-            var project = tracker.GetCurrentProject();
+            var project = tracker.GetCurrentProjectAsync();
 
             Assert.NotNull(project);
         }
@@ -128,7 +144,7 @@ namespace PivotalTrackerTests.Services
             var response = CreateResponse(returnProject);
             FakeHttpService.Setup(x => x.GetAsync(It.IsAny<string>())).Returns(Task.FromResult(response));
 
-            var project = tracker.GetCurrentProject(1);
+            var project = tracker.GetCurrentProjectAsync(1);
 
             Assert.NotNull(project);
         }
@@ -146,7 +162,7 @@ namespace PivotalTrackerTests.Services
             var response = CreateResponse(returnStories);
             FakeHttpService.Setup(x => x.GetAsync(It.IsAny<string>())).Returns(Task.FromResult(response));
 
-            var stories = tracker.GetProjectStories(1);
+            var stories = tracker.GetProjectStoriesAsync(1);
 
             Assert.NotNull(stories);
         }

--- a/PivotalTrackerTests/Services/PivotalTrackerTestClass.cs
+++ b/PivotalTrackerTests/Services/PivotalTrackerTestClass.cs
@@ -42,7 +42,7 @@ namespace PivotalTrackerTests.Services
             tracker.AuthorizeAsync("testUser", "testPassword");
             FakeHttpService.Setup(x => x.GetAsync(It.IsAny<string>())).Returns(Task.FromResult(response));
 
-            var user = tracker.GetUser().Result;
+            var user = tracker.GetUserAsync().Result;
 
             Assert.Equal(user.ApiToken, returnUser.ApiToken);
         }
@@ -93,9 +93,9 @@ namespace PivotalTrackerTests.Services
             var response = CreateResponse(returnUser);
             FakeHttpService.Setup(x => x.GetAsync(It.IsAny<string>())).Returns(Task.FromResult(response));
 
-            var user = tracker.GetUser();
+            var user = tracker.GetUserAsync().Result;
 
-            Assert.Equal(user.Id, returnUser.Id);
+            Assert.Equal(returnUser.Id, user.Id);
         }
 
         [Fact]
@@ -111,7 +111,7 @@ namespace PivotalTrackerTests.Services
             var response = CreateResponse(returnProjects);
             FakeHttpService.Setup(x => x.GetAsync(It.IsAny<string>())).Returns(Task.FromResult(response));
 
-            var projects = tracker.GetProjects().Result;
+            var projects = tracker.GetProjectsAsync().Result;
 
             Assert.Equal(3, projects.Count);
         }

--- a/README.md
+++ b/README.md
@@ -8,16 +8,24 @@ Development Build Status: [![Build status](https://ci.appveyor.com/api/projects/
 ## About
 The .NET Wrapper for Pivotal Tracker API is a .NET wrapper to enable easy use of the Pivotal Tracker REST API. It is current compatible with .NET4.5 and UAP10.0 applications.
 
+**Note: There have been breaking changes in version 1.1.0-Alpha. If you are currently using the package, please be aware of the changes. The changes are noted in the [Release Notes](https://github.com/mbrewerton/DotNetPivotalTrackerApi#release-notes).**
+
 You can access the nuget package here: [Nuget Package](https://www.nuget.org/packages/Mbrewerton.DotNetPivotalTrackerApi).
 
 ## Contribution
 Anyone can contribute to the project via Pull Requests (PRs), but all PRs must be created against the `develop` branch. Contribution branches would preferably be created using gitflow - Create a branch called `feature/your_feature_to_add` from `develop` and then create a PR for `feature/your_feature_to_add` -> `develop`. If you are picking off an item in the TODO list, please include the item name in the description section of your PR.
 
-## Basic Guide
-To start using the API, create a new PivotalTracker instance `PivotalTracker tracker = new PivotalTracker(YourApiToken)` and you can use all methods in the package from that instance. You must pass a Pivotal Tracker API Key to the PivotalTracker class as it uses this to communicate with the REST API. You can have multiple instances at once with multiple API keys if needed:
+## Quickstart Guide
+To start using the API, create a new PivotalTracker instance `PivotalTracker tracker = new PivotalTracker(YourApiToken)` and you can use all methods in the package from that instance. You can have multiple instances at once with multiple API keys if needed:
 ``` C#
 PivotalTracker personalTracker = new PivotalTracker(PersonalApiKey);
 PivotalTracker businessTracker = new PivotalTracker(BusinessApiKey);
+```
+
+If you don't wish to expose your API token, or you have anoher requirement that means you need to use credential authorisation, you can do so by using the `AuthorizeAsync` method.
+``` C#
+PivotalTracker tracker = new PivotalTracker();
+await tracker.AuthorizeAsync("Username", "Password");
 ```
 
 ## Examples
@@ -33,7 +41,7 @@ In order to authenticate using credentials, you need to instantiate your tracker
 ``` C#
 // Note the use of the default constructor. We don't want to pass a token here!
 PivotalTracker tracker = new PivotalTracker();
-// If this call succeeds, your `tracker` instance is now authenticated. Note that this method is async
+// If the `AuthorizeAsync` call succeeds, your `tracker` instance is now authenticated
 await tracker.AuthorizeAsync("myusername", "mypassword");
 
 // If you want to use AuthorizeAsync in a non-async method, you can use .Result. Your authenticated user will be returned if successful.
@@ -46,7 +54,7 @@ You can use the API to get your user data as well as specific REST actions:
 ``` C#
 PivotalTracker tracker = new PivotalTracker(_apiKey_);
 
-PivotalUser user = tracker.GetUser();
+PivotalUser user = await tracker.GetUserAsync();
 Console.WriteLine($"User Info: {user.Name} ({user.Initials}) has username {user.Username} and Email {user.Email}");
 ```
 All methods return an object, including any POST or PUT methods. This means you can use previously created objects when making subsequent calls. DELETE requests will return a boolean, returning `true` if it was successful. If there was an error, a `PivotalHttpException` will be thrown allowing you to try/catch for it. The exception message will include the full error message from Pivtotal Tracker.
@@ -57,10 +65,10 @@ PivotalTracker tracker = new PivotalTracker(_apiKey_);
 int projectId = 1357;
 
 // Create a new story with c'tor
-PivotalStory savedStory = tracker.CreateNewStory(projectId, "My new Feature", StoryType.feature, null, "My description");
+PivotalStory savedStory = await tracker.CreateNewStoryAsync(projectId, "My new Feature", StoryType.feature, null, "My description");
 
 // Create a new story with a pre-made object
-PivotalNewStory myBug = new PivotalNewStory
+PivotalNewStory myBug = new PivotalStory
 {
   Name = "My new story",
   Description = "My new description",
@@ -70,21 +78,29 @@ PivotalNewStory myBug = new PivotalNewStory
       "My label"
   }
 }
-PivotalStory savedBug = tracker.CreateNewStory(projectId, myBug);
+PivotalStory savedBug = await tracker.CreateNewStoryAsync(projectId, myBug);
 ```
 
 ### Adding a Task to a Story
 ``` C#
 int projectId = 1357;
-PivotalStory story = tracker.GetProjectStories(projectId).First();
-PivotalTask storyTask = tracker.CreateNewStoryTask(projectId, story.Id, "This is a task");
+PivotalStory story = await tracker.GetProjectStoriesAsync(projectId).First();
+PivotalTask storyTask = await tracker.CreateNewStoryTaskAsync(projectId, story.Id, "This is a task");
 ```
 
 ## Release Notes
 
+### 1.1.0-Alpha
+- **[Breaking Change]** Removed the "PivotalNew" models. All methods (Get and Create) now use the same model
+- **[Breaking Change]** Refactored public PivotalTracker methods to be async
+  - All methods have been renamed to include the `Async` suffix. Eg: `GetProjects()` => `GetProjectsAsync()`
+- Added authorisation for username/password authentication
+  - see the [Authentication Section](https://github.com/mbrewerton/DotNetPivotalTrackerApi#types-of-authentication)
+- Fixed credential authorisation hanging in Portable C# applications
+
 ### 1.0.6-Alpha
 - Added authorisation for username/password authentication
-  - see the [Authentication Section](https://www.nuget.org/packages/Mbrewerton.DotNetPivotalTrackerApi#types-of-authentication)
+  - see the [Authentication Section](https://github.com/mbrewerton/DotNetPivotalTrackerApi#types-of-authentication)
 
 ### 1.0.4-Alpha
 - Fixed previously broken build


### PR DESCRIPTION
- **[Breaking Change]** Removed the "PivotalNew" models. All methods (Get and Create) now use the same model
- **[Breaking Change]** Refactored public PivotalTracker methods to be async
  - All methods have been renamed to include the `Async` suffix. Eg: `GetProjects()` => `GetProjectsAsync()`
- Added authorisation for username/password authentication
- Fixed credential authorisation hanging in Portable C# applications